### PR TITLE
Fundamental econnomical api

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,17 @@ resp = client.get_macro_indicator('CHL', indicator='real_interest_rate')
 ```python
 resp = client.get_fundamentals_bonds(cusip='US00213MAS35')
 ```
+
+- **Historical market capitalization API**: Get historical Market Capitalization data, EOD Historical data cover all US stocks traded on NYSE/NASDAQ from 2017. Soon they will start to cover cryptocurrencies with historical market capitalization.
+	- Parameters:
+		- ```symbol```(str): Required - Name of the instrument to retrieve data. Consists of two parts: {SYMBOL_NAME}.{EXCHANGE_ID}. For example, MCD.MX for Mexican Stock Exchange or MCD.US for NYSE. Check the [list of supported exchanges](https://eodhistoricaldata.com/financial-apis/list-supported-exchanges/) to get more information about the stock markets the API support.
+		- ```from_```(str) and ```to```(str): Optional - The format is 'YYYY-MM-DD'. If you need data from Jan 5, 2017, to Feb 10, 2017, you should use ```from_='2017-01-05'``` and ```to='2017-02-10'```.
+	- Usage:
+```python
+# Request the historical market capitalization for Visa
+resp = client.get_market_cap(symbol='V.US', from_='2020-01-01')
+```
+
 ### Exchanges Financial APIs [:arrow_up:](#eod-historical-data-sdk)
 - **Bulk API for EOD, Splits and Dividends**: This method allows you to download the data for an entire exchange for a particular day. It works for end-of-day historical data feed and splits and dividends data as well. You can also use NYSE or NASDAQ as exchange symbols for US tickers to get data only for NYSE or NASDAQ exchange. With this method is no longer necessary to perform thousands and thousands of API requests per day.
 	- Parameters:

--- a/eod/fundamental_economic_data/fundamental_economic.py
+++ b/eod/fundamental_economic_data/fundamental_economic.py
@@ -10,9 +10,11 @@ from eod.fundamental_economic_data.calendar_earnings_trends_ipos_splits_api impo
 from eod.fundamental_economic_data.macroeconomic_api import MacroEconomicIndicators
 from eod.fundamental_economic_data.insider_transactions_api import InsiderTransactions
 from eod.fundamental_economic_data.economic_events_data_api import EconomicEventsData
+from eod.fundamental_economic_data.historical_market_capitalization_api import HistoricalMarketCapitalization
 
 class FundamentalEconomicData(StockEtfFundsIndexFundamentalData, CalendarEarningsTrendsIposSplits,
-                              MacroEconomicIndicators, InsiderTransactions, EconomicEventsData):
+                              MacroEconomicIndicators, InsiderTransactions, EconomicEventsData,
+                              HistoricalMarketCapitalization):
     def __init__(self, api_key:str, timeout:int):
         # inhereting the API classes
         StockEtfFundsIndexFundamentalData.__init__(self, api_key, timeout)
@@ -20,3 +22,4 @@ class FundamentalEconomicData(StockEtfFundsIndexFundamentalData, CalendarEarning
         MacroEconomicIndicators.__init__(self, api_key, timeout)
         InsiderTransactions.__init__(self, api_key, timeout)
         EconomicEventsData.__init__(self, api_key, timeout)
+        HistoricalMarketCapitalization.__init__(self, api_key, timeout)

--- a/eod/fundamental_economic_data/historical_market_capitalization_api/__init__.py
+++ b/eod/fundamental_economic_data/historical_market_capitalization_api/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jun 16 10:28:01 2022
+
+@author: lauta
+"""
+
+from .market_capitalization import HistoricalMarketCapitalization

--- a/eod/fundamental_economic_data/historical_market_capitalization_api/market_capitalization.py
+++ b/eod/fundamental_economic_data/historical_market_capitalization_api/market_capitalization.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Thu Jun 16 10:20:59 2022
+
+@author: lauta
+"""
+
+from eod.request_handler_class import RequestHandler
+
+class HistoricalMarketCapitalization(RequestHandler):
+    def __init__(self, api_key:str, timeout:int):
+        # base URL's of the API
+        self.URL_MARKET_CAP = 'https://eodhistoricaldata.com/api/historical-market-cap/'
+        super().__init__(api_key, timeout)
+        
+    def get_market_cap(self, symbol:str, **query_params):
+        """
+        Request the historical market cap (from 2017) for stocks and cryptocurrencies
+
+        Parameters
+        ----------
+        symbol : str
+            Financial instrument to request.
+        **query_params :
+            personalized parameters for the method.
+
+        Returns
+        -------
+        dict
+            Historical market capitalization for the specified instrument.
+
+        """
+        self.endpoint = self.URL_MARKET_CAP + symbol.upper()
+        return super().handle_request(self.endpoint, query_params) 

--- a/sandbox.py
+++ b/sandbox.py
@@ -71,6 +71,8 @@ resp = client.get_macro_indicator_name()
 resp = client.get_macro_indicator('CHL', indicator='real_interest_rate')
 # Insider Transactions API
 resp = client.get_insider_transactions(limit=100)
+# Historical market capitalization
+resp = client.get_market_cap(symbol='V.US', from_='2020-01-01')
 
 
 # Questions and changes


### PR DESCRIPTION
Implementation of the Historical market capitalization API. You can use this endpoint with the method `get_market_cap` (code plus documentation).