### PR TITLE
fix: remove pandas and numpy from dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 HERE = pathlib.Path(__file__).parent
 
-VERSION = '0.2.1'
+VERSION = '0.2.2'
 PACKAGE_NAME = 'eod'
 AUTHOR = 'Lautaro Parada Opazo'
 AUTHOR_EMAIL = 'lautaro.parada.opazo@gmail.com'
@@ -15,8 +15,6 @@ LONG_DESCRIPTION = (HERE / "README.md").read_text(encoding="utf8")
 LONG_DESC_TYPE = "text/markdown"
 
 INSTALL_REQUIRES = [
-      'numpy',
-      'pandas',
       'requests'
 ]
 


### PR DESCRIPTION
Hey, I've noticed that `numpy` and `pandas` seems like an extra dependencies.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/a3f7b2bf-7b5e-4523-ae98-f2dfaaffb2a5" />
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/802d7712-df76-4b51-afa8-0fefa4f0583a" />
